### PR TITLE
Make /ping of php-fpm work again

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -763,6 +763,8 @@ static int fpm_worker_pool_shared_status_alloc(struct fpm_worker_pool_s *shared_
 	FPM_WPC_STR_CP(config, shared_config, user);
 	FPM_WPC_STR_CP(config, shared_config, group);
 	FPM_WPC_STR_CP(config, shared_config, pm_status_path);
+	FPM_WPC_STR_CP(config, shared_config, ping_path);
+	FPM_WPC_STR_CP(config, shared_config, ping_response);
 
 	fpm_conf_apply_kv_array_to_kv_array(shared_config->php_values, (char *)config + WPO(php_values));
 	fpm_conf_apply_kv_array_to_kv_array(shared_config->php_admin_values, (char *)config + WPO(php_admin_values));


### PR DESCRIPTION
The ping feature of php-fpm monitoring was previously not working (but the status is) due to the configuration variables `ping.path` and `ping.response` not being copied over to the worker when forked (but `pm.status_path` does). This results in the ping code path being disabled because the worker detects that ping.path is not configured.